### PR TITLE
add gpt-3.5-turbo autoanswering, fix bugs

### DIFF
--- a/pollevbot/autoanswer.py
+++ b/pollevbot/autoanswer.py
@@ -1,0 +1,15 @@
+import openai
+openai.api_key = API_KEY
+
+def get_answer(question):
+	prompt = f"You are QuizGPT, an LLM designed to provide the id of the right answer to quiz questions. You will be provided with a question, and potential answers. Each answer is proceeded by its id, a 9 digit number. For instance, for the line \"123456789: C) test\", the number 123456789 is the id, and the rest is the answer body. Answer the following question by providing only the id of the correct answer. You MUST choose one of the answers included in the prompt. Do not explain your thinking. The question is:\n{question}"
+
+	print(question)
+
+	completion = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=[{"role": "user", "content": prompt}])
+	return completion.choices[0].message.content
+
+if __name__ == "__main__":
+	print(get_answer("""Which of these equations is correct?
+132375398: A) 2+2=5
+132375399: B) 2+2=4"""))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ chardet==3.0.4
 idna==2.9
 pytz==2020.1
 requests==2.23.0
+openai==0.27.4
+termcolor==2.2.0
 six==1.14.0
 soupsieve==2.0
 tzlocal==2.0.0


### PR DESCRIPTION
the change in line 216 is because the poll may be open but hosting a leaderboard (or something else that doesn't include options in the response).
I am not sure about line 193 (why it used to work) but I could only get it to work this way.
instead of this approach which completely removes random answering in favor of AI, answer_poll could be rewritten to accept an answering function as a parameter, which would then provide the option_id answer_poll submits, so that AI and random answering could be easily interchangeable.